### PR TITLE
Added a checker for dir and removed the previous checker

### DIFF
--- a/tone-analyzer-nlu-java/src/main/java/com/ibm/demo/ToneAnalyzerNLU.java
+++ b/tone-analyzer-nlu-java/src/main/java/com/ibm/demo/ToneAnalyzerNLU.java
@@ -52,14 +52,6 @@ public class ToneAnalyzerNLU {
 				|| properties.getProperty("TEST_DATA_DIR") == null) {
 			System.err.println("Error: Service credentials and/or test data dir  missing. Terminating ...");
 			System.exit(1);
-		} else {
-			// Adjust UNIX style path in TEST_DATA_DIR property if running on Windows
-			if (properties.getProperty("TEST_DATA_DIR").contains("/")) {
-				if (File.pathSeparatorChar != '/') {
-					String windowsPath = properties.getProperty("TEST_DATA_DIR").replaceAll("/", File.pathSeparator);
-					properties.setProperty("TEST_DATA_DIR", windowsPath);
-				}
-			}
 		}
 
 		// Create service clients
@@ -83,7 +75,11 @@ public class ToneAnalyzerNLU {
 		// Get all txt files in test data folder
 		File dir = new File(properties.getProperty("TEST_DATA_DIR"));
 		String[] extensions = new String[] { "txt" };
-
+		
+		if (!dir.isDirectory()) {
+			dir = new File(properties.getProperty("TEST_DATA_DIR").replaceAll("\\.\\.", ""));
+		}
+		
 		List<File> files = (List<File>) FileUtils.listFiles(dir, extensions, true);
 
 		System.out.println("Analyzing " + files.size() + " earnings call transcripts");


### PR DESCRIPTION
This checker should be able to check to see if the dir variable (../test_data) contains files, if not, alter the variable (/test_data) and try again. This should account for both Eclipse and IntelliJ environments. I removed the previous checker as it was interfering with proper execution.